### PR TITLE
Updated Kapt  options for Glide V4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
+//Updated version of glide V4 requires double declaration of kapt in gradle; else an error occurs
+apply plugin: 'kotlin-kapt'
+
 android {
     compileSdkVersion 27
     defaultConfig {


### PR DESCRIPTION
In the latest library of Glide V4 ,, it i required to declare the Kapt function twice inorder for Gradle to Build well